### PR TITLE
Added support for 'b' and 'B' data formats to the lenEst() function

### DIFF
--- a/Struct.java
+++ b/Struct.java
@@ -342,6 +342,8 @@ public class Struct {
                 counter+=4;
             else if (x=='h' || x=='H')
                 counter+=2;
+            else if (x=='b' || x=='B')
+                counter+=1;
         }
         return counter;
     }


### PR DESCRIPTION
I added support for the 'b' and 'B' data formats to the lenEst() function in order to correctly calculate the estimated length of binary formatting data. The 'b' and 'B' data formats are used for unsigned bytes.

I have tested the changes and confirm that they work correctly.
Thank you for considering this pull merge request.